### PR TITLE
__downchunks() 增加 GET 参数 ru

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -106,6 +106,7 @@ import httplib
 import urllib
 import json
 import hashlib
+import base64
 import binascii
 import re
 import cPickle as pickle
@@ -2429,6 +2430,10 @@ try to create a file at PCS by combining slices, having MD5s specified
 				headers = { "Range" : "bytes=0-{}".format(rsize - 1) }
 			else:
 				headers = {}
+
+			if headers.has_key('Range'):
+				self.pd("headers['Range'][6:]: {} {}".format(headers['Range'][6:], base64.standard_b64encode(headers['Range'][6:])))
+				pars['ru'] = base64.standard_b64encode(headers['Range'][6:])
 
 			subresult = self.__get(dpcsurl + 'file', pars,
 				self.__downchunks_act, (rfile, offset, rsize, start_time), headers = headers)

--- a/bypy.py
+++ b/bypy.py
@@ -1412,7 +1412,7 @@ class ByPy(object):
 		kwnew = kwargs.copy()
 		if 'headers' not in kwnew:
 			kwnew['headers'] = { 'User-Agent': UserAgent }
-		else:
+		if 'User-Agent' not in kwnew['headers']:
 			kwnew['headers']['User-Agent'] = UserAgent
 
 		while True:
@@ -2410,6 +2410,9 @@ try to create a file at PCS by combining slices, having MD5s specified
 
 		pars = {
 			'method' : 'download',
+			'app_id': 250528,
+			'check_blue' : '1',
+			'ec' : '1',
 			'path' : rfile }
 
 		offset = start
@@ -2435,8 +2438,12 @@ try to create a file at PCS by combining slices, having MD5s specified
 				self.pd("headers['Range'][6:]: {} {}".format(headers['Range'][6:], base64.standard_b64encode(headers['Range'][6:])))
 				pars['ru'] = base64.standard_b64encode(headers['Range'][6:])
 
+			headers['User-Agent'] = 'netdisk;5.2.7.2;PC;PC-Windows;6.2.9200;WindowsBaiduYunGuanJia'
+
+			self.pd("headers2: {}".format(headers))
+
 			subresult = self.__get(dpcsurl + 'file', pars,
-				self.__downchunks_act, (rfile, offset, rsize, start_time), headers = headers)
+				self.__downchunks_act, (rfile, offset, rsize, start_time), headers = headers, cookies = self.__pancookies)
 			if subresult != ENoError:
 				return subresult
 


### PR DESCRIPTION
试图解决 #163 `{
    "error_code":31326,
    "error_msg":"anti hotlinking"
}`

我目前只遇到一个文件<sup>1</sup>出现这个提示，样本不足，不敢说这招一定有效。
1. `59015a999df43c53f10bd54e0520843e` / `9ab5b9b2806d850fb935b40793291c845bda4715`

猜测触发的条件是：同一个 URI 被反复请求。
这个改动模仿了百度云管家的 `ru` 参数，间接使得每次请求的 URI 不一样：

```
ru: MC0yMDk3MTUxOQ==
ru: MjA5NzE1MjAtNDE5NDMwMzk=
ru: NDE5NDMwNDAtNjI5MTQ1NTk=
ru: NjI5MTQ1NjAtODM4ODYwNzk=
ru: ODM4ODYwODAtMTA0ODU3NTk5
ru: MTA0ODU3NjAwLTEyNTgyOTExOQ==
ru: MTI1ODI5MTIwLTE0NjgwMDYzOQ==
```

（并没有完全模拟百度云管家的请求。）

---

已知的样本文件见：https://github.com/xslidian/bypy/pull/1#issuecomment-123606567
